### PR TITLE
修复执行php bin/swoft stop失败，但pid文件仍被删除的问题

### DIFF
--- a/src/Command/ServerCommand.php
+++ b/src/Command/ServerCommand.php
@@ -122,7 +122,6 @@ class ServerCommand
         $serverStatus = $httpServer->getServerSetting();
         $pidFile = $serverStatus['pfile'];
 
-        @unlink($pidFile);
         \output()->writeln(sprintf('<info>Swoft %s is stopping ...</info>', input()->getScript()));
 
         $result = $httpServer->stop();
@@ -131,6 +130,8 @@ class ServerCommand
         if (!$result) {
             \output()->writeln(sprintf('<error>Swoft %s stop fail</error>', input()->getScript()), true, true);
         }
+        //删除pid文件
+        @unlink($pidFile);
 
         output()->writeln(sprintf('<success>Swoft %s stop success!</success>', input()->getScript()));
     }


### PR DESCRIPTION
在执行stop操作之后根据返回结果再决定是否删除pid文件