### PR TITLE
验证请求参数合法性时，传入当前请求方式

### DIFF
--- a/src/Middleware/ValidatorMiddleware.php
+++ b/src/Middleware/ValidatorMiddleware.php
@@ -40,6 +40,8 @@ class ValidatorMiddleware implements MiddlewareInterface
             return $handler->handle($request);
         }
 
+        $requestMethod = $request->getMethod();
+
         // Controller and method
         $handlerId = $route->getHandler();
         [$className, $method] = explode('@', $handlerId);
@@ -64,8 +66,7 @@ class ValidatorMiddleware implements MiddlewareInterface
         $validator = BeanFactory::getBean('validator');
 
         /* @var Request $request */
-        [$parsedBody, $query] = $validator->validateRequest($parsedBody, $validates, $query);
-
+        [$parsedBody, $query] = $validator->validateRequest($parsedBody, $validates, $query, $requestMethod);
         if ($notParsedBody) {
             $parsedBody = $data;
         }


### PR DESCRIPTION
验证当前请求参数合法性时，将当前请求方式传入，然后根据请求方式 来判断是该从 queryString 或requestbody中获取参数值，然后进行验证，没有传入时现在只是根据validator的type属性来验证的，针对支持多种方式的请求处理错误。