### PR TITLE
fix annotation RequestMapping name not saving to Route Object.

### DIFF
--- a/src/Router/RouteRegister.php
+++ b/src/Router/RouteRegister.php
@@ -77,7 +77,7 @@ class RouteRegister
                 $path    = $routePath[0] === '/' ? $routePath : $prefix . '/' . $routePath;
                 $handler = $class . '@' . $route['action'];
 
-                $router->map($route['method'], $path, $handler, $route['params']);
+                $router->map($route['method'], $path, $handler, $route['params'], ['name' => $route['name']]);
             }
         }
     }


### PR DESCRIPTION
解决注解设置RequestMapping的路由名称没有生效的问题